### PR TITLE
Change timescroller's position

### DIFF
--- a/ACTimeScroller/ACTimeScroller.m
+++ b/ACTimeScroller/ACTimeScroller.m
@@ -401,9 +401,11 @@
     
     CGRect selfFrame = self.frame;
     CGRect scrollBarFrame = _scrollBar.frame;
-    
+    CGFloat moveingDistance = _tableView.contentSize.height - _scrollBar.frame.size.height;
+    CGFloat ratio = _scrollBar.frame.origin.y / moveingDistance;
+
     self.frame = CGRectMake(CGRectGetWidth(selfFrame) * -1.0f,
-                            (CGRectGetHeight(scrollBarFrame) / 2.0f) - (CGRectGetHeight(selfFrame) / 2.0f),
+                            (CGRectGetHeight(scrollBarFrame) - CGRectGetHeight(selfFrame)) * ratio,
                             CGRectGetWidth(selfFrame),
                             CGRectGetHeight(_backgroundView.frame));
     
@@ -465,10 +467,11 @@
     
     CGRect selfFrame = self.frame;
     CGRect scrollBarFrame = _scrollBar.frame;
-    
-    
+    CGFloat moveingDistance = _tableView.contentSize.height - _scrollBar.frame.size.height;
+    CGFloat ratio = _scrollBar.frame.origin.y / moveingDistance;
+
     self.frame = CGRectIntegral(CGRectMake(CGRectGetWidth(selfFrame) * -1.0f,
-                                           (CGRectGetHeight(scrollBarFrame) / 2.0f) - (CGRectGetHeight(selfFrame) / 2.0f),
+                                           (CGRectGetHeight(scrollBarFrame) - CGRectGetHeight(selfFrame)) * ratio,
                                            CGRectGetWidth(selfFrame),
                                            CGRectGetHeight(selfFrame)));
     


### PR DESCRIPTION
If timescroller use centre of scroll ber as its position centre, it can't reach top and bottom of table.
![ios simulator screen shot may 22 2013 6 37 02 pm](https://f.cloud.github.com/assets/291175/547459/b2055722-c2c3-11e2-9698-a5cb4eaba8ea.png)

I tried to change Timescroller's position. 
![ios simulator screen shot may 22 2013 6 37 31 pm](https://f.cloud.github.com/assets/291175/547460/b7289bc4-c2c3-11e2-8855-cc2d9c004139.png)
