### PR TITLE
Updated captureTableViewAndScrollBar to support iPad on iOS 7

### DIFF
--- a/ACTimeScroller/ACTimeScroller.m
+++ b/ACTimeScroller/ACTimeScroller.m
@@ -142,7 +142,7 @@
         {
             UIImageView *imageView = (UIImageView *)subview;
             
-            if (imageView.frame.size.width == 7.0f || imageView.frame.size.width == 3.5f)
+            if (imageView.frame.size.width == 7.0f || imageView.frame.size.width == 5.0f || imageView.frame.size.width == 3.5f)
             {
                 imageView.clipsToBounds = NO;
                 [imageView addSubview:self];


### PR DESCRIPTION
UIScrollView scrollbars on iOS 7 iPad have a width of `5.0f`, so I modified the `captureTableViewAndScrollBar` method to catch that.
